### PR TITLE
Updates the parameter parser so it returns an exception if no .tf fil…

### DIFF
--- a/lambda-functions/terraform_open_source_parameter_parser/main.go
+++ b/lambda-functions/terraform_open_source_parameter_parser/main.go
@@ -32,6 +32,6 @@ func HandleRequest(event TerraformOpenSourceParameterParserInput) (TerraformOpen
 		return TerraformOpenSourceParameterParserResponse{}, fileMapErr
 	}
 
-	parameters := ParseParametersFromConfiguration(fileMap)
-	return TerraformOpenSourceParameterParserResponse{Parameters: parameters}, nil
+	parameters, parseParametersErr := ParseParametersFromConfiguration(fileMap)
+	return TerraformOpenSourceParameterParserResponse{Parameters: parameters}, parseParametersErr
 }

--- a/lambda-functions/terraform_open_source_parameter_parser/parser.go
+++ b/lambda-functions/terraform_open_source_parameter_parser/parser.go
@@ -13,7 +13,7 @@ import (
 const PrimaryModuleName = "PrimaryModule"
 const OverrideModuleName = "OverrideModule"
 const OverrideFileSuffix = "override.tf"
-const NoFilesToParseExceptionMessage = "No .tf files found. Nothing to parse. Make sure the root directory of the artifact contains the .tf files for the root module."
+const NoFilesToParseExceptionMessage = "No .tf files found. Nothing to parse. Make sure the root directory of the Terraform open source configuration file contains the .tf files for the root module."
 
 // ParseParametersFromConfiguration - Takes Terraform configuration represented as a map from file name to string contents
 // parses out the variable blocks and returns slice of Parameter pointers

--- a/lambda-functions/terraform_open_source_parameter_parser/parser.go
+++ b/lambda-functions/terraform_open_source_parameter_parser/parser.go
@@ -13,17 +13,24 @@ import (
 const PrimaryModuleName = "PrimaryModule"
 const OverrideModuleName = "OverrideModule"
 const OverrideFileSuffix = "override.tf"
+const NoFilesToParseExceptionMessage = "No .tf files found. Nothing to parse. Make sure the root directory of the artifact contains the .tf files for the root module."
 
 // ParseParametersFromConfiguration - Takes Terraform configuration represented as a map from file name to string contents
 // parses out the variable blocks and returns slice of Parameter pointers
-func ParseParametersFromConfiguration(fileMap map[string]string) []*Parameter {
+func ParseParametersFromConfiguration(fileMap map[string]string) ([]*Parameter, error) {
+	if len(fileMap) == 0 {
+		return nil, ParserInvalidParameterException{
+			Message: NoFilesToParseExceptionMessage,
+		}
+	}
+
 	primaryFileMap, overrideFileMap := bisectFileMap(fileMap)
 
 	primaryParameterMap := parseParameterMapFromFileMap(primaryFileMap, PrimaryModuleName)
 	overrideParameterMap := parseParameterMapFromFileMap(overrideFileMap, OverrideModuleName)
 	parameters := mergeParameterMaps(primaryParameterMap, overrideParameterMap)
 
-	return parameters
+	return parameters, nil
 }
 
 // bisects the original file map into primaryFileMap and overrideFileMap

--- a/lambda-functions/terraform_open_source_parameter_parser/parser_test.go
+++ b/lambda-functions/terraform_open_source_parameter_parser/parser_test.go
@@ -51,9 +51,12 @@ func TestParseParametersFromConfigurationHappy(t *testing.T) {
 	expectedResultMap["test_variable_complex_type"] = expectedParameter3
 
 	// act
-	actualResult := ParseParametersFromConfiguration(fileMap)
+	actualResult, err := ParseParametersFromConfiguration(fileMap)
 
 	// assert
+	if err != nil {
+		t.Errorf("Unexpected error returned. %v", err)
+	}
 
 	// assert the number of parameters parsed is as expected
 	if len(actualResult) != len(expectedResultMap) {
@@ -127,9 +130,13 @@ func TestParseParametersFromConfigurationWithOverrideFilesHappy(t *testing.T) {
 	expectedResultMap["new_variable_from_override"] = expectedParameter4
 
 	// act
-	actualResult := ParseParametersFromConfiguration(fileMap)
+	actualResult, err := ParseParametersFromConfiguration(fileMap)
 
 	// assert
+	if err != nil {
+		t.Errorf("Unexpected error returned. %v", err)
+	}
+
 
 	// assert the number of parameters parsed is as expected
 	if len(actualResult) != len(expectedResultMap) {
@@ -237,9 +244,12 @@ func TestParseParametersFromConfigurationWithComprehensiveVariableFileHappy(t *t
 	expectedResultMap["tuple_variable"] = expectedParameter8
 
 	// act
-	actualResult := ParseParametersFromConfiguration(fileMap)
+	actualResult, err := ParseParametersFromConfiguration(fileMap)
 
 	// assert
+	if err != nil {
+		t.Errorf("Unexpected error returned. %v", err)
+	}
 
 	// assert the number of parameters parsed is as expected
 	if len(actualResult) != len(expectedResultMap) {
@@ -263,5 +273,19 @@ func TestParseParametersFromConfigurationWithComprehensiveVariableFileHappy(t *t
 	// assert all parameters were parsed
 	if len(expectedResultMap) != 0 {
 		t.Errorf("Not all expected parameters were parsed")
+	}
+}
+
+func TestParseParametersFromConfigurationWithNoFilesThrowsParserInvalidParameterException(t *testing.T) {
+	// setup
+	fileMap := make(map[string]string)
+	expectedErrorMessage := "No .tf files found. Nothing to parse. Make sure the root directory of the artifact contains the .tf files for the root module."
+
+	// act
+	_, err := ParseParametersFromConfiguration(fileMap)
+
+	// assert
+	if !reflect.DeepEqual(err, ParserInvalidParameterException{Message: expectedErrorMessage}) {
+		t.Errorf("Validator did not throw ParserInvalidParameterException with expected error message")
 	}
 }

--- a/lambda-functions/terraform_open_source_parameter_parser/parser_test.go
+++ b/lambda-functions/terraform_open_source_parameter_parser/parser_test.go
@@ -279,7 +279,7 @@ func TestParseParametersFromConfigurationWithComprehensiveVariableFileHappy(t *t
 func TestParseParametersFromConfigurationWithNoFilesThrowsParserInvalidParameterException(t *testing.T) {
 	// setup
 	fileMap := make(map[string]string)
-	expectedErrorMessage := "No .tf files found. Nothing to parse. Make sure the root directory of the artifact contains the .tf files for the root module."
+	expectedErrorMessage := "No .tf files found. Nothing to parse. Make sure the root directory of the Terraform open source configuration file contains the .tf files for the root module."
 
 	// act
 	_, err := ParseParametersFromConfiguration(fileMap)


### PR DESCRIPTION
*Description*

Updates the parameter parser so it returns an exception if no .tf files can be found in the artifact's root directory.

This will prevent unexpected noop results when the artifact file is compressed/archived with all the files in a top-level directory, rather than the root-module files at the root of the archive. 

A second PR will be published to raise an exception when a provision or update operation is attempted on a an artifact with no .tf files in the root directory.

*Testing*

1. Ran go test on the parser code
1. Invoked from the lambda console
    * Valid artifact with 2 variables
    * Valid artifact with no variables
    * Invalid artifact: No .tf files in the root directory returns exception
1. Tested with Service Catalog console and describe-provisioning-parameters CLI:
    * Valid artifact with 2 variables
    * Valid artifact with no variables
    * Invalid artifact: No .tf files in the root directory returns exception

