### PR TITLE
Raises error during provision/update if no .tf files found

### DIFF
--- a/lambda-functions/terraform_open_source_parameter_parser/main.go
+++ b/lambda-functions/terraform_open_source_parameter_parser/main.go
@@ -32,6 +32,6 @@ func HandleRequest(event TerraformOpenSourceParameterParserInput) (TerraformOpen
 		return TerraformOpenSourceParameterParserResponse{}, fileMapErr
 	}
 
-	parameters := ParseParametersFromConfiguration(fileMap)
-	return TerraformOpenSourceParameterParserResponse{Parameters: parameters}, nil
+	parameters, parseParametersErr := ParseParametersFromConfiguration(fileMap)
+	return TerraformOpenSourceParameterParserResponse{Parameters: parameters}, parseParametersErr
 }

--- a/lambda-functions/terraform_open_source_parameter_parser/parser.go
+++ b/lambda-functions/terraform_open_source_parameter_parser/parser.go
@@ -13,7 +13,7 @@ import (
 const PrimaryModuleName = "PrimaryModule"
 const OverrideModuleName = "OverrideModule"
 const OverrideFileSuffix = "override.tf"
-const NoFilesToParseExceptionMessage = "No .tf files found. Nothing to parse. Make sure the root directory of the artifact contains the .tf files for the root module."
+const NoFilesToParseExceptionMessage = "No .tf files found. Nothing to parse. Make sure the root directory of the Terraform open source configuration file contains the .tf files for the root module."
 
 // ParseParametersFromConfiguration - Takes Terraform configuration represented as a map from file name to string contents
 // parses out the variable blocks and returns slice of Parameter pointers

--- a/lambda-functions/terraform_open_source_parameter_parser/parser.go
+++ b/lambda-functions/terraform_open_source_parameter_parser/parser.go
@@ -13,17 +13,24 @@ import (
 const PrimaryModuleName = "PrimaryModule"
 const OverrideModuleName = "OverrideModule"
 const OverrideFileSuffix = "override.tf"
+const NoFilesToParseExceptionMessage = "No .tf files found. Nothing to parse. Make sure the root directory of the artifact contains the .tf files for the root module."
 
 // ParseParametersFromConfiguration - Takes Terraform configuration represented as a map from file name to string contents
 // parses out the variable blocks and returns slice of Parameter pointers
-func ParseParametersFromConfiguration(fileMap map[string]string) []*Parameter {
+func ParseParametersFromConfiguration(fileMap map[string]string) ([]*Parameter, error) {
+	if len(fileMap) == 0 {
+		return nil, ParserInvalidParameterException{
+			Message: NoFilesToParseExceptionMessage,
+		}
+	}
+
 	primaryFileMap, overrideFileMap := bisectFileMap(fileMap)
 
 	primaryParameterMap := parseParameterMapFromFileMap(primaryFileMap, PrimaryModuleName)
 	overrideParameterMap := parseParameterMapFromFileMap(overrideFileMap, OverrideModuleName)
 	parameters := mergeParameterMaps(primaryParameterMap, overrideParameterMap)
 
-	return parameters
+	return parameters, nil
 }
 
 // bisects the original file map into primaryFileMap and overrideFileMap

--- a/lambda-functions/terraform_open_source_parameter_parser/parser_test.go
+++ b/lambda-functions/terraform_open_source_parameter_parser/parser_test.go
@@ -51,9 +51,12 @@ func TestParseParametersFromConfigurationHappy(t *testing.T) {
 	expectedResultMap["test_variable_complex_type"] = expectedParameter3
 
 	// act
-	actualResult := ParseParametersFromConfiguration(fileMap)
+	actualResult, err := ParseParametersFromConfiguration(fileMap)
 
 	// assert
+	if err != nil {
+		t.Errorf("Unexpected error returned. %v", err)
+	}
 
 	// assert the number of parameters parsed is as expected
 	if len(actualResult) != len(expectedResultMap) {
@@ -127,9 +130,13 @@ func TestParseParametersFromConfigurationWithOverrideFilesHappy(t *testing.T) {
 	expectedResultMap["new_variable_from_override"] = expectedParameter4
 
 	// act
-	actualResult := ParseParametersFromConfiguration(fileMap)
+	actualResult, err := ParseParametersFromConfiguration(fileMap)
 
 	// assert
+	if err != nil {
+		t.Errorf("Unexpected error returned. %v", err)
+	}
+
 
 	// assert the number of parameters parsed is as expected
 	if len(actualResult) != len(expectedResultMap) {
@@ -237,9 +244,12 @@ func TestParseParametersFromConfigurationWithComprehensiveVariableFileHappy(t *t
 	expectedResultMap["tuple_variable"] = expectedParameter8
 
 	// act
-	actualResult := ParseParametersFromConfiguration(fileMap)
+	actualResult, err := ParseParametersFromConfiguration(fileMap)
 
 	// assert
+	if err != nil {
+		t.Errorf("Unexpected error returned. %v", err)
+	}
 
 	// assert the number of parameters parsed is as expected
 	if len(actualResult) != len(expectedResultMap) {
@@ -263,5 +273,19 @@ func TestParseParametersFromConfigurationWithComprehensiveVariableFileHappy(t *t
 	// assert all parameters were parsed
 	if len(expectedResultMap) != 0 {
 		t.Errorf("Not all expected parameters were parsed")
+	}
+}
+
+func TestParseParametersFromConfigurationWithNoFilesThrowsParserInvalidParameterException(t *testing.T) {
+	// setup
+	fileMap := make(map[string]string)
+	expectedErrorMessage := "No .tf files found. Nothing to parse. Make sure the root directory of the artifact contains the .tf files for the root module."
+
+	// act
+	_, err := ParseParametersFromConfiguration(fileMap)
+
+	// assert
+	if !reflect.DeepEqual(err, ParserInvalidParameterException{Message: expectedErrorMessage}) {
+		t.Errorf("Validator did not throw ParserInvalidParameterException with expected error message")
 	}
 }

--- a/lambda-functions/terraform_open_source_parameter_parser/parser_test.go
+++ b/lambda-functions/terraform_open_source_parameter_parser/parser_test.go
@@ -279,7 +279,7 @@ func TestParseParametersFromConfigurationWithComprehensiveVariableFileHappy(t *t
 func TestParseParametersFromConfigurationWithNoFilesThrowsParserInvalidParameterException(t *testing.T) {
 	// setup
 	fileMap := make(map[string]string)
-	expectedErrorMessage := "No .tf files found. Nothing to parse. Make sure the root directory of the artifact contains the .tf files for the root module."
+	expectedErrorMessage := "No .tf files found. Nothing to parse. Make sure the root directory of the Terraform open source configuration file contains the .tf files for the root module."
 
 	// act
 	_, err := ParseParametersFromConfiguration(fileMap)

--- a/wrapper-scripts/terraform_runner/test_artifact_manager.py
+++ b/wrapper-scripts/terraform_runner/test_artifact_manager.py
@@ -7,7 +7,8 @@ class TestArtifactManager(unittest.TestCase):
 
     @patch('terraform_runner.artifact_manager.boto3.client')
     @patch('tarfile.open')
-    def test_download_artifact_happy_path(self, mock_tarfile_open, mock_client):
+    @patch('terraform_runner.artifact_manager.glob')
+    def test_download_artifact_happy_path(self, mock_glob, mock_tarfile_open, mock_client):
         # arrange
         mock_sts = Mock()
         mock_s3 = Mock()
@@ -26,6 +27,8 @@ class TestArtifactManager(unittest.TestCase):
         artifact_path = f's3://{artifact_bucket}/{artifact_key}'
         workspace_dir = 'workspace/dir'
         local_file = f'{workspace_dir}/artifact.local'
+
+        mock_glob.return_value = ['mock.tf']
 
         # act
         download_artifact(launch_role_arn, artifact_path, workspace_dir)
@@ -107,6 +110,49 @@ class TestArtifactManager(unittest.TestCase):
             download_artifact(launch_role_arn, artifact_path, workspace_dir)
         self.assertEqual(context.expected, RuntimeError)
         self.assertTrue(context.exception.args[0].startswith(f'Invalid artifact path {artifact_path}'))
+
+    @patch('terraform_runner.artifact_manager.boto3.client')
+    @patch('tarfile.open')
+    @patch('terraform_runner.artifact_manager.glob')
+    def test_download_artifact_no_terraform_files(self, mock_glob, mock_tarfile_open, mock_client):
+        # arrange
+        mock_sts = Mock()
+        mock_s3 = Mock()
+        mock_client.side_effect = [mock_sts, mock_s3]
+        mock_credentials = {
+            'AccessKeyId': 'access-key',
+            'SecretAccessKey': 'secret-key',
+            'SessionToken': 'session-token'
+        }
+        mock_assume_role_response = {'Credentials': mock_credentials}
+        mock_sts.assume_role.return_value = mock_assume_role_response
+
+        launch_role_arn = 'launch-role-arn'
+        artifact_bucket = 'artifact-bucket'
+        artifact_key = 'artifact'
+        artifact_path = f's3://{artifact_bucket}/{artifact_key}'
+        workspace_dir = 'workspace/dir'
+        local_file = f'{workspace_dir}/artifact.local'
+
+        mock_glob.return_value = []
+
+        # act
+        with self.assertRaises(RuntimeError) as context:
+            download_artifact(launch_role_arn, artifact_path, workspace_dir)
+
+        # assert
+        mock_sts.assume_role.assert_called_once_with(RoleArn=launch_role_arn,
+                                                     RoleSessionName=ROLE_SESSION_NAME)
+        mock_client.assert_called_with('s3',
+                                       aws_access_key_id=mock_credentials['AccessKeyId'],
+                                       aws_secret_access_key=mock_credentials['SecretAccessKey'],
+                                       aws_session_token=mock_credentials['SessionToken'])
+        mock_s3.download_file.assert_called_once_with(artifact_bucket, artifact_key,
+                                                      local_file)
+        mock_tarfile_open.assert_called_once_with('artifact.local')
+
+        self.assertEqual(context.expected, RuntimeError)
+        self.assertEqual(str(context.exception), 'No .tf files found. Nothing to parse. Make sure the root directory of the Terraform open source configuration file contains the .tf files for the root module.')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
*Description*

Raises error during provision/update if no .tf files found

*Testing*

* python3 -m unittest on terraform_runner
* Service Catalog integration tests:Provision, update, and terminate
    * artifact with no .tf files in the root directory. Fails to provision and gives expected error message
    * Artifact with one .tf file in the root directory. Provisions successfully.
    * Artifact with multiple .tf files in the root directory. Provisions successfully.
