### PR TITLE
Fix the bug when TRE failed to send failure notice to SC when SSM tim…

### DIFF
--- a/statemachine/manage_provisioned_product.json
+++ b/statemachine/manage_provisioned_product.json
@@ -227,16 +227,29 @@
                                 },
                                 {
                                     "Variable": "$.pollCommandInvocationResponse.invocationStatus",
-                                    "StringEquals": "TimedOut"
-                                },
-                                {
-                                    "Variable": "$.pollCommandInvocationResponse.invocationStatus",
                                     "StringEquals": "Cancelled"
                                 }
                             ]
                         }
                     ],
                     "Next": "Convert error structure"
+                },
+                {
+                    "And": [
+                        {
+                            "Variable": "$.pollCommandInvocationResponse.invocationStatus",
+                            "IsPresent": true
+                        },
+                        {
+                            "Variable": "$.pollCommandInvocationResponse.invocationStatus",
+                            "IsString": true
+                        },
+                        {
+                            "Variable": "$.pollCommandInvocationResponse.invocationStatus",
+                            "StringEquals": "TimedOut"
+                        }
+                    ],
+                    "Next": "Convert timed out structure"
                 },
                 {
                     "And": [
@@ -312,6 +325,17 @@
             "Parameters": {
                 "Error": "Error running terraform-runner script",
                 "Cause.$": "$.pollCommandInvocationResponse.errorMessage",
+                "isWrapperError": true
+            },
+            "ResultPath": "$.errorInfo",
+            "Next": "Is failed operation an update or provision?"
+        },
+        "Convert timed out structure": {
+            "Type": "Pass",
+            "Comment": "Restructures message from timed out command invocation task in a format Notify SC failure task understands",
+            "Parameters": {
+                "Error": "Error running terraform-runner script",
+                "Cause.$": "States.Format('SSM run command execution with commandId {} timed out', $.sendApplyCommandResponse.commandId)",
                 "isWrapperError": true
             },
             "ResultPath": "$.errorInfo",

--- a/statemachine/terminate_provisioned_product.json
+++ b/statemachine/terminate_provisioned_product.json
@@ -212,16 +212,29 @@
                                 },
                                 {
                                     "Variable": "$.pollCommandInvocationResponse.invocationStatus",
-                                    "StringEquals": "TimedOut"
-                                },
-                                {
-                                    "Variable": "$.pollCommandInvocationResponse.invocationStatus",
                                     "StringEquals": "Cancelled"
                                 }
                             ]
                         }
                     ],
                     "Next": "Convert error structure"
+                },
+                {
+                    "And": [
+                        {
+                            "Variable": "$.pollCommandInvocationResponse.invocationStatus",
+                            "IsPresent": true
+                        },
+                        {
+                            "Variable": "$.pollCommandInvocationResponse.invocationStatus",
+                            "IsString": true
+                        },
+                        {
+                            "Variable": "$.pollCommandInvocationResponse.invocationStatus",
+                            "StringEquals": "TimedOut"
+                        }
+                    ],
+                    "Next": "Convert timed out structure"
                 },
                 {
                     "And": [
@@ -249,6 +262,17 @@
             "Parameters": {
                 "Error": "Error running terraform-runner script",
                 "Cause.$": "$.pollCommandInvocationResponse.errorMessage",
+                "isWrapperError": true
+            },
+            "ResultPath": "$.errorInfo",
+            "Next": "Notify terminate failure result"
+        },
+        "Convert timed out structure": {
+            "Type": "Pass",
+            "Comment": "Restructures message from timed out command invocation task in a format Notify SC failure task understands",
+            "Parameters": {
+                "Error": "Error running terraform-runner script",
+                "Cause.$": "States.Format('SSM run command execution with commandId {} timed out', $.sendDestroyCommandResponse.commandId)",
                 "isWrapperError": true
             },
             "ResultPath": "$.errorInfo",


### PR DESCRIPTION
*Description of changes:*


Fix the bug for an edge case when TRE fails to send failure notice to SC when SSM times out.

With this change, TRE will send failure notice even if SSM times out for provision/update/terminate operations.

*Testing:*

Manually forced SSM to timeout in local test account during provisioning. Confirmed that with the updated changes, the step function workflow executed successfully, and the corresponding provisioned product updated to TAINTED with the expected status message.