### PR TITLE
Restrict access to a specific endpoint for TerraformStateBucket

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -517,6 +517,16 @@ Resources:
                   - !GetAtt TerraformAutoscalingGroupRole.Arn
             Resource:
               - !Sub ${TerraformStateBucket.Arn}/*
+          - Sid: DenyAccessToPublicEndpoint
+            Action: s3:*
+            Effect: Deny
+            Principal:
+              AWS: "*"
+            Condition:
+              StringNotEquals:
+                aws:SourceVpce: !Ref S3GatewayEndpoint
+            Resource:
+              - !Sub ${TerraformStateBucket.Arn}/*
 
   TerraformAutoscalingGroup:
     Type: AWS::AutoScaling::AutoScalingGroup


### PR DESCRIPTION
*Description*
 Create VPC endpoint to restrict access to the TerrformStateBucket.

*Testing*
- Deployed to an AWS account using the updated template.yaml file.
- Tested the bucket cannot be accessed from outside the vpc without using the endpoint.
- The workflow looks good.

