### PR TITLE
Bug fix of deploying a new S3 bucket with ACL settings.

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -406,7 +406,6 @@ Resources:
     Type: 'AWS::S3::Bucket'
     Properties:
       BucketName: !Sub 'sc-terraform-engine-logging-${AWS::AccountId}-${AWS::Region}'
-      AccessControl: LogDeliveryWrite
       VersioningConfiguration:
         Status: Enabled
       BucketEncryption:


### PR DESCRIPTION
Required to work around the issue https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-ownership-error-responses.html#object-ownership-error-responses-invalid-acl

Testing
---------
* Tested locally to see S3 API calls is added to logging bucket.

Issue
---------
https://github.com/aws-samples/service-catalog-engine-for-terraform-os/issues/24
