### PR TITLE
Replace soon deprecated policy AmazonEC2RoleforSSM in the template

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -668,7 +668,8 @@ Resources:
             Action:
               - sts:AssumeRole
       ManagedPolicyArns:
-        - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AmazonEC2RoleforSSM
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/AmazonSSMManagedInstanceCore
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/CloudWatchAgentServerPolicy
       Policies:
         - PolicyName: S3ObjectAccessPolicy
           PolicyDocument:


### PR DESCRIPTION
*Description of changes:*

This PR replaces soon deprecated `AmazonEC2RoleforSSM` managed policy with `AmazonSSMManagedInstanceCore` and `CloudWatchAgentServerPolicy` managed policies according to this [AWS blog post](https://aws.amazon.com/blogs/mt/applying-managed-instance-policy-best-practices/).


*Testing:*

Deployed with updated template. Verified `TerraformExecutionRole` is updated with the new policies. Tried the provision and terminate workflows with the new policies and everything runs fine.

*Issue:*

Fixes #25 