### PR TITLE
Update parameter parser to use default ServiceCatalogTerraformOSParam…

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,9 +222,9 @@ Only files with .tf filename extension in the zipped .tar.gz provisioning artifa
 
 #### Launch Role
 
-The Service Catalog Terraform Open Source Parameter Parser assumes the provided launch role to download the artifact
+The Service Catalog Terraform Open Source Parameter Parser assumes the provided launch role to download the artifact if a launch role is provided in the payload. If no launch role is provided, parameter parser will use the default lambda execution role ServiceCatalogTerraformOSParameterParserRole credentials to download the artifact.
 
-The launch role arn must be a valid IAM arn that has access to the artifact and is assumable by the parser lambda
+If provided, the launch role arn must be a valid IAM arn that has access to the artifact and is assumable by the parser lambda.
 
 ### Override Files
 

--- a/lambda-functions/terraform_open_source_parameter_parser/config_fetcher_test.go
+++ b/lambda-functions/terraform_open_source_parameter_parser/config_fetcher_test.go
@@ -67,3 +67,38 @@ func TestConfigFetcherFetchHappy(t *testing.T) {
 		t.Errorf("File content for %s is not as expected", TestS3BucketArtifactFileName)
 	}
 }
+
+func TestConfigFetcherFetchWithEmptyLaunchRoleHappy(t *testing.T) {
+	// setup
+	downloader := new(MockS3Downloader)
+	s3Downloader := &S3Downloader{
+		downloader: downloader,
+	}
+	configFetcher := &ConfigFetcher{
+		s3Downloader: s3Downloader,
+	}
+	input := TerraformOpenSourceParameterParserInput{
+		Artifact: Artifact{
+			Path: TestArtifactPath,
+			Type: TestArtifactType,
+		},
+		LaunchRoleArn: "",
+	}
+
+	// act
+	fileMap, err := configFetcher.fetch(input)
+
+	// assert
+	if err != nil {
+		t.Errorf("Unexpected error occured")
+	}
+
+	fileContent, ok := fileMap[TestS3BucketArtifactFileName]
+	if !ok {
+		t.Errorf("Expected file %s was not parsed", TestS3BucketArtifactFileName)
+	}
+
+	if reflect.DeepEqual(fileContent, TestS3BucketArtifactFileContent) {
+		t.Errorf("File content for %s is not as expected", TestS3BucketArtifactFileName)
+	}
+}

--- a/lambda-functions/terraform_open_source_parameter_parser/validator.go
+++ b/lambda-functions/terraform_open_source_parameter_parser/validator.go
@@ -22,7 +22,6 @@ const InvalidLaunchRoleArnSyntaxErrorMessage = "LaunchRoleArn %s is not a syntac
 const InvalidIamLaunchRoleArnErrorMessage = "LaunchRoleArn %s is not a valid iam ARN"
 const InvalidArtifactTypeErrorMessage = "Artifact type %s is not supported, must be AWS_S3"
 const InvalidArtifactPathErrorMessage = "Artifact path %s is not a valid S3 URI"
-const InvalidArtifactFileNameMessage = "Artifact path %s is not valid, must end with .tar.gz"
 
 // ValidateInput - Validates TerraformOpenSourceParameterParserInput
 // Returns a non nil error if an invalid input is provided
@@ -52,12 +51,6 @@ func validateRequiredKeysExist(input TerraformOpenSourceParameterParserInput) er
 		}
 	}
 
-	if input.LaunchRoleArn == "" {
-		return ParserInvalidParameterException{
-			Message: fmt.Sprintf(RequiredKeyMissingOrEmptyErrorMessage, LaunchRoleArnKey),
-		}
-	}
-
 	if input.Artifact.Path == "" {
 		return ParserInvalidParameterException{
 			Message: fmt.Sprintf(RequiredKeyMissingOrEmptyErrorMessage, ArtifactPathKey),
@@ -74,6 +67,12 @@ func validateRequiredKeysExist(input TerraformOpenSourceParameterParserInput) er
 }
 
 func validateLaunchRoleArnIsSyntacticallyCorrect(launchRoleArnString string) error {
+
+	// skip validation if launch role is not provided
+	if launchRoleArnString == "" {
+		return nil
+	}
+
 	launchRoleArn, err := arn.Parse(launchRoleArnString)
 	if err != nil {
 		return ParserInvalidParameterException{

--- a/lambda-functions/terraform_open_source_parameter_parser/validator_test.go
+++ b/lambda-functions/terraform_open_source_parameter_parser/validator_test.go
@@ -25,24 +25,7 @@ func TestValidateInputHappy(t *testing.T) {
 	}
 }
 
-func TestValidateInputWithEmptyArtifactThrowsParserInvalidParameterException(t *testing.T) {
-	// setup
-	input := TerraformOpenSourceParameterParserInput{
-		Artifact: Artifact{},
-		LaunchRoleArn: TestLaunchRoleArn,
-	}
-	expectedErrorMessage := fmt.Sprintf(RequiredKeyMissingOrEmptyErrorMessage, ArtifactKey)
-
-	// act
-	err := ValidateInput(input)
-
-	// assert
-	if !reflect.DeepEqual(err, ParserInvalidParameterException{Message: expectedErrorMessage}) {
-		t.Errorf("Validator did not throw ParserInvalidParameterException with expected error message")
-	}
-}
-
-func TestValidateInputWithEmptyLaunchRoleArnThrowsParserInvalidParameterException(t *testing.T) {
+func TestValidateInputWithEmptyLaunchRoleHappy(t *testing.T) {
 	// setup
 	input := TerraformOpenSourceParameterParserInput{
 		Artifact: Artifact{
@@ -51,7 +34,23 @@ func TestValidateInputWithEmptyLaunchRoleArnThrowsParserInvalidParameterExceptio
 		},
 		LaunchRoleArn: "",
 	}
-	expectedErrorMessage := fmt.Sprintf(RequiredKeyMissingOrEmptyErrorMessage, LaunchRoleArnKey)
+
+	// act
+	err := ValidateInput(input)
+
+	// assert
+	if err != nil {
+		t.Errorf("Validation failed for happy path input with empty launch role")
+	}
+}
+
+func TestValidateInputWithEmptyArtifactThrowsParserInvalidParameterException(t *testing.T) {
+	// setup
+	input := TerraformOpenSourceParameterParserInput{
+		Artifact: Artifact{},
+		LaunchRoleArn: TestLaunchRoleArn,
+	}
+	expectedErrorMessage := fmt.Sprintf(RequiredKeyMissingOrEmptyErrorMessage, ArtifactKey)
 
 	// act
 	err := ValidateInput(input)

--- a/template.yaml
+++ b/template.yaml
@@ -1004,6 +1004,9 @@ Resources:
               - Action: [ 'sts:AssumeRole' ]
                 Effect: Allow
                 Resource: !Sub "arn:${AWS::Partition}:iam::*:role/SCLaunch*"
+              - Action: [ 's3:Get*' ]
+                Effect: Allow
+                Resource: "arn:aws:s3:::*"
             Version: '2012-10-17'
           PolicyName: lambdaPermissions
       AssumeRolePolicyDocument:


### PR DESCRIPTION
*Description of changes:*

Update parameter parser to use default lambda execution role `ServiceCatalogTerraformOSParameterParserRole` creds to fetch artifact when launch role is not provided.

*Testing:*

* `go test`
* Invoke parameter parser lambda with a valid launch role and it successfully uses launch role creds to fetch the artifact
* Invoke parameter parser lambda with an empty launch role and it successfully uses default  `ServiceCatalogTerraformOSParameterParserRole` creds to fetch the artifact
* Invoke parameter parser lambda with no launch role in the payload and it successfully uses default  `ServiceCatalogTerraformOSParameterParserRole` creds to fetch the artifact