### PR TITLE
Fix resource ARN to be compatible with all AWS partitions

### DIFF
--- a/cfn-templates/TerraformProvisioningAccount.yaml
+++ b/cfn-templates/TerraformProvisioningAccount.yaml
@@ -53,7 +53,7 @@ Resources:
                   - s3:Get*
                   - s3:List*
                   - s3:PutBucketTagging
-                Resource: "arn:aws:s3:::*"
+                Resource: !Sub "arn:${AWS::Partition}:s3:::*"
               # Resource group and tagging permissions required for Service Catalog terraform open source products
               - Effect: Allow
                 Action:

--- a/sample-provisioning-artifacts/Readme.md
+++ b/sample-provisioning-artifacts/Readme.md
@@ -33,7 +33,7 @@ Example:
                   - s3:Get*
                   - s3:List*
                   - s3:PutBucketTagging
-                Resource: "arn:aws:s3:::*"
+                Resource: !Sub "arn:${AWS::Partition}:s3:::*"
               - Effect: Allow
                 Action: 
                   - resource-groups:CreateGroup
@@ -90,7 +90,7 @@ Example:
                   - s3:PutBucketNotification
                   - s3:PutBucketWebsite
                   - s3:PutBucketTagging
-                Resource: "arn:aws:s3:::*"
+                Resource: !Sub "arn:${AWS::Partition}:s3:::*"
               - Effect: Allow
                 Action: 
                   - sns:CreateTopic

--- a/template.yaml
+++ b/template.yaml
@@ -1005,7 +1005,7 @@ Resources:
                 Resource: !Sub "arn:${AWS::Partition}:iam::*:role/*"
               - Action: [ 's3:GetObject' ]
                 Effect: Allow
-                Resource: "arn:aws:s3:::*"
+                Resource: !Sub "arn:${AWS::Partition}:s3:::*"
                 Condition:
                   StringEquals:
                     "s3:ExistingObjectTag/servicecatalog:provisioning": "true"


### PR DESCRIPTION
*Description of changes:*

Fix resource ARN to be compatible with all AWS partitions. Currently some S3 resource ARN only works in classic AWS partition.

*Testing:*

Deployed TRE again - provision, update, terminate succeeds after the changes