### PR TITLE
Fixes single quoted string in user params

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ In this step we build the Python scripts that will run on EC2 instances to manag
 1. The default settings can be overridden by passing the parameters in the `template.yaml`. 
    * Example command for updating the default VPC setting -
       `--parameter-overrides VpcCidr="<Your_VpcCidr>" PublicSubnet1CIDR="<Your_PublicSubnet1CIDR>" PrivateSubnet1CIDR="<Your_PrivateSubnet1CIDR>"`
+   * Example command for updating the default EC2 instance type setting -
+     `--parameter-overrides EC2InstanceType="<Your_EC2InstanceType>"`
 
 ## Replace Current EC2 Instances
 

--- a/lambda-functions/state_machine_lambdas/core/cli.py
+++ b/lambda-functions/state_machine_lambdas/core/cli.py
@@ -25,3 +25,23 @@ def double_escape_double_quotes_and_backslashes(input: str) -> str:
     if '\\' in input:
         input = input.replace('\\', '\\\\')
     return input.replace('"', '\\"')
+
+def triple_escape_double_single_quotes(input: str) -> str:
+    """Add triple escape backslashes and a double single quotes in a string.
+    Used to allow single quotes in user paramenter in command parameter string.
+    If input is empty or None, input is returned
+    """
+    if not input:
+        return input
+    return input.replace("'", "'\\\''")
+
+def escape_quotes_backslashes(input: str) -> str:
+    """
+        For double backslashes adds double backslash
+        For single double adds double backslashes
+        For single quotes adds double backslashes and double single quotes
+    """
+    if not input:
+        return input
+    input =  double_escape_double_quotes_and_backslashes(input)
+    return triple_escape_double_single_quotes(input)

--- a/lambda-functions/state_machine_lambdas/core/test_cli.py
+++ b/lambda-functions/state_machine_lambdas/core/test_cli.py
@@ -1,6 +1,6 @@
 from unittest import main, TestCase
 
-from core.cli import create_runuser_command_with_default_user, double_escape_double_quotes, double_escape_double_quotes_and_backslashes, triple_escape_double_single_quotes
+from core.cli import create_runuser_command_with_default_user, double_escape_double_quotes, double_escape_double_quotes_and_backslashes, triple_escape_double_single_quotes, escape_quotes_backslashes
 
 class TestCli(TestCase):
 
@@ -133,6 +133,18 @@ class TestCli(TestCase):
 
         # Assert
         self.assertEqual(expected, actual)
+    
+    def test_escape_quotes_backslashes_happy_path(self):
+        # Arrange
+        input = [None, '', '"key": "aws_amis", "value": "{\"us-east-1\":\"ami-5f709f34\",\"us-west-2\":\"ami-7f675e4f\"}"', "Testing it's all good ?"]
+        expected = [None, '', '\\"key\\": \\"aws_amis\\", \\"value\\": \\"{\\\"us-east-1\\\":\\\"ami-5f709f34\\\",\\\"us-west-2\\\":\\\"ami-7f675e4f\\\"}\\"', "Testing it'\\''s all good ?"]
+        
+        for index, data in enumerate(input):
+            # Act
+            actual = escape_quotes_backslashes(data)
+
+            # Assert
+            self.assertEqual(expected[index], actual)
 
 if __name__ == '__main__':
     main()

--- a/lambda-functions/state_machine_lambdas/core/test_cli.py
+++ b/lambda-functions/state_machine_lambdas/core/test_cli.py
@@ -1,6 +1,6 @@
 from unittest import main, TestCase
 
-from core.cli import create_runuser_command_with_default_user, double_escape_double_quotes, double_escape_double_quotes_and_backslashes
+from core.cli import create_runuser_command_with_default_user, double_escape_double_quotes, double_escape_double_quotes_and_backslashes, triple_escape_double_single_quotes
 
 class TestCli(TestCase):
 
@@ -99,6 +99,40 @@ class TestCli(TestCase):
         # Assert
         self.assertEqual(expected, actual)
 
+    def test_triple_escape_double_single_quotes_happy_path(self):
+        # Arrange
+        input = "Testing user's parameter"
+        expected = "Testing user'\\''s parameter"
+
+        # Act
+        actual = triple_escape_double_single_quotes(input)
+
+        # Assert
+        self.assertEqual(expected, actual)
+
+
+    def test_triple_escape_double_single_quotes_input_is_None(self):
+        # Arrange
+        input = None
+        expected = None
+
+        # Act
+        actual = triple_escape_double_single_quotes(input)
+
+        # Assert
+        self.assertEqual(expected, actual)
+
+
+    def test_triple_escape_double_single_quotes_input_is_empty(self):
+        # Arrange
+        input = ''
+        expected = ''
+
+        # Act
+        actual = triple_escape_double_single_quotes(input)
+
+        # Assert
+        self.assertEqual(expected, actual)
 
 if __name__ == '__main__':
     main()

--- a/lambda-functions/state_machine_lambdas/send_apply_command.py
+++ b/lambda-functions/state_machine_lambdas/send_apply_command.py
@@ -2,7 +2,7 @@ import json
 import logging
 import os
 
-from core.cli import create_runuser_command_with_default_user, double_escape_double_quotes, double_escape_double_quotes_and_backslashes
+from core.cli import create_runuser_command_with_default_user, escape_quotes_backslashes
 from core.configuration import Configuration
 from core.exception import log_exception
 from core.ssm_facade import SsmFacade
@@ -111,7 +111,7 @@ def __get_tags_text(event: dict) -> str:
     total_tags = [event[TRACER_TAG_KEY]]
     if TAGS_KEY in event:
         total_tags += event[TAGS_KEY]
-    return double_escape_double_quotes_and_backslashes(json.dumps(total_tags))
+    return escape_quotes_backslashes(json.dumps(total_tags))
 
 def __get_command_text(event: dict) -> str:
     """Creates the command to run on the instance based on the Lambda input event.
@@ -125,7 +125,7 @@ def __get_command_text(event: dict) -> str:
     -------
         str: The command text
     """
-    artifact_parameters_text = double_escape_double_quotes_and_backslashes(__get_optional_json(event, PARAMETERS_KEY))
+    artifact_parameters_text = escape_quotes_backslashes(__get_optional_json(event, PARAMETERS_KEY))
     tags_text = __get_tags_text(event)
 
     base_command = f"""python3 -m terraform_runner --action=apply \

--- a/template.yaml
+++ b/template.yaml
@@ -116,6 +116,11 @@ Parameters:
     MinValue: 128
     MaxValue: 10240
 
+  EC2InstanceType:
+    Default: t2.medium
+    Description: The type of EC2 instance used by the auto scaling group
+    Type: String
+
 Resources:
   # VPC for Terraform Reference Engine
   VPC:
@@ -592,7 +597,7 @@ Resources:
         IamInstanceProfile:
           Name: !Ref TerraformInstanceProfile
         ImageId: !Ref ServerLatestAmiId
-        InstanceType: t2.micro
+        InstanceType: !Ref EC2InstanceType
         MetadataOptions:
           HttpTokens: required
         UserData:


### PR DESCRIPTION

*Description of changes:* Added changes to allow users to have single quotes in the parameter string. 

Testing:
Deployed TRE again - provision, update, terminate succeeds after the changes