### PR TITLE
Use t2.medium as default for EC2 instance type and add parameter over…

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ In this step we build the Python scripts that will run on EC2 instances to manag
 1. The default settings can be overridden by passing the parameters in the `template.yaml`. 
    * Example command for updating the default VPC setting -
       `--parameter-overrides VpcCidr="<Your_VpcCidr>" PublicSubnet1CIDR="<Your_PublicSubnet1CIDR>" PrivateSubnet1CIDR="<Your_PrivateSubnet1CIDR>"`
+   * Example command for updating the default EC2 instance type setting -
+     `--parameter-overrides EC2InstanceType="<Your_EC2InstanceType>"`
 
 ## Replace Current EC2 Instances
 

--- a/template.yaml
+++ b/template.yaml
@@ -116,6 +116,11 @@ Parameters:
     MinValue: 128
     MaxValue: 10240
 
+  EC2InstanceType:
+    Default: t2.medium
+    Description: The type of EC2 instance used by the auto scaling group
+    Type: String
+
 Resources:
   # VPC for Terraform Reference Engine
   VPC:
@@ -592,7 +597,7 @@ Resources:
         IamInstanceProfile:
           Name: !Ref TerraformInstanceProfile
         ImageId: !Ref ServerLatestAmiId
-        InstanceType: t2.micro
+        InstanceType: !Ref EC2InstanceType
         MetadataOptions:
           HttpTokens: required
         UserData:


### PR DESCRIPTION
*Description of changes:*

Use `t2.medium` as default for EC2 instance type used by the auto scaling group since Terraform recommends at least 4 GB of RAM [here](https://developer.hashicorp.com/terraform/enterprise/system-overview/capacity). This would address some failing executions due to memory issues while using the previous `t2.micro` instance type. Also added the capability to override this parameter.

*Testing:*

* Updated TRE to use `t2.medium` and provision, update, terminate operations succeed after the update