### PR TITLE
fix: remove inbound ssh traffic authorization

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -86,15 +86,6 @@ Parameters:
     Description: Please enter the IP range (CIDR notation) for the private subnet 3 (not supported in all regions)
     Type: String
 
-  SSHLocation:
-    AllowedPattern: '(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})/(\d{1,2})'
-    ConstraintDescription: must be a valid IP CIDR range of the form x.x.x.x/x.
-    Default: 0.0.0.0/0
-    Description: The IP address range that can be used to access the instance using SSH.
-    MaxLength: 18
-    MinLength: 9
-    Type: String
-
   RIPMoreThan2AZsParameter:
     Default: 'false'
     Type: String
@@ -384,13 +375,17 @@ Resources:
   InstanceSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
-      GroupDescription: SSH (port 22)
+      GroupDescription: TerraformEngineInstanceSecurityGroup
       VpcId: !Ref VPC
-      SecurityGroupIngress:
+      SecurityGroupEgress:
         - IpProtocol: tcp
-          FromPort: 22
-          ToPort: 22
-          CidrIp: !Ref SSHLocation
+          FromPort: 80
+          ToPort: 80
+          CidrIp: 0.0.0.0/0
+        - IpProtocol: tcp
+          FromPort: 443
+          ToPort: 443
+          CidrIp: 0.0.0.0/0
 
   S3GatewayEndpoint:
     Type: AWS::EC2::VPCEndpoint


### PR DESCRIPTION
## Summary
 
This commit removes all ingress traffic authorizations from the security group attached to the TRE execution 
instances to reduce the attack surface of the TRE execution instances.

   1. Removes the ingress rule that previously authorized inbound connections to port `tcp/22` 
       from unrestricted networks (e.g., `0.0.0.0/0`) by default.

   2. Replaces the egress rule that permitted all outbound traffic to any destination with rules 
       that limit egress traffic to `http/80` and `https/443` to `0.0.0.0/0`.

## Testing 

These changes were successfully deployed to both a pre-existing TRE environment and a completely 
new TRE environment. All AWS Service Catalog operations related to the TRE components 
(e.g., `CreateProvisionedProduct`, `UpdateProvisionedProduct`, and `TerminateProvisionedProduct`) 
were successfully tested in a multi-account AWS Control Tower environment, to include portfolios 
shared directly with account principals and through AWS Organizations.

_See `V945951784` for additional testing details._