### PR TITLE
Fix #73 default to Intel Skylake E5 2686 v5 instances (aka t3.medium)

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -108,7 +108,7 @@ Parameters:
     MaxValue: 10240
 
   EC2InstanceType:
-    Default: t2.medium
+    Default: t3.medium
     Description: The type of EC2 instance used by the auto scaling group
     Type: String
 


### PR DESCRIPTION
*Issue #, if available:*

Read #73 

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
