### PR TITLE
Update Parameter Parser Lambda runtimes from go1.x to provided.al2

### DIFF
--- a/lambda-functions/terraform_open_source_parameter_parser/Makefile
+++ b/lambda-functions/terraform_open_source_parameter_parser/Makefile
@@ -1,0 +1,6 @@
+build-ParameterParser:
+	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o bootstrap
+	cp ./bootstrap "$(ARTIFACTS_DIR)/."
+build-ExternalParameterParser:
+	GOOS=linux GOARACH=amd64 CGO_ENABLED=0 go build -o bootstrap
+	cp ./bootstrap "$(ARTIFACTS_DIR)/."

--- a/template.yaml
+++ b/template.yaml
@@ -1036,7 +1036,7 @@ Resources:
     Properties:
       FunctionName: ServiceCatalogTerraformOSParameterParser
       CodeUri: lambda-functions/terraform_open_source_parameter_parser/
-      Handler: terraform_open_source_parameter_parser
+      Handler: bootstrap
       VpcConfig:
         SubnetIds: !If
           - MoreThan2AZs
@@ -1050,7 +1050,7 @@ Resources:
             - - !Ref PrivateSubnet1
         SecurityGroupIds:
           - !GetAtt VPC.DefaultSecurityGroup
-      Runtime: go1.x
+      Runtime: provided.al2
       Architectures:
         - x86_64
       MemorySize: !Ref ParameterParserLambdaMemorySize
@@ -1059,13 +1059,15 @@ Resources:
         Fn::GetAtt:
           - ParameterParserRole
           - Arn
+    Metadata:
+      BuildMethod: makefile
 
   ExternalParameterParser:
     Type: AWS::Serverless::Function
     Properties:
       FunctionName: ServiceCatalogExternalParameterParser
       CodeUri: lambda-functions/terraform_open_source_parameter_parser/
-      Handler: terraform_open_source_parameter_parser
+      Handler: bootstrap
       VpcConfig:
         SubnetIds: !If
           - MoreThan2AZs
@@ -1079,7 +1081,7 @@ Resources:
             - - !Ref PrivateSubnet1
         SecurityGroupIds:
           - !GetAtt VPC.DefaultSecurityGroup
-      Runtime: go1.x
+      Runtime: provided.al2
       Architectures:
         - x86_64
       MemorySize: !Ref ParameterParserLambdaMemorySize
@@ -1088,6 +1090,8 @@ Resources:
         Fn::GetAtt:
           - ExternalParameterParserRole
           - Arn
+    Metadata:
+      BuildMethod: makefile
 
   ParameterParserRole:
     Type: AWS::IAM::Role


### PR DESCRIPTION
## Description
The go1.x Lambda runtime will be deprecated on 2023/12/31

This change follows the migration instructions provided in this guide:
https://aws.amazon.com/blogs/compute/migrating-aws-lambda-functions-from-the-go1-x-runtime-to-the-custom-runtime-on-amazon-linux-2/

## Testing
Deployed with `./bin/bash/deploy-tre.sh` and confirmed same functionality by calling `DescribeProvisioningParameters` API



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
