### PR TITLE
update trust policy

### DIFF
--- a/cfn-templates/TerraformProvisioningAccount.yaml
+++ b/cfn-templates/TerraformProvisioningAccount.yaml
@@ -31,6 +31,7 @@ Resources:
                 "aws:PrincipalArn":
                   - !Sub arn:${AWS::Partition}:iam::${TerraformEngineAccount}:role/TerraformEngine/TerraformExecutionRole*
                   - !Sub arn:${AWS::Partition}:iam::${TerraformEngineAccount}:role/TerraformEngine/ServiceCatalogTerraformOSParameterParserRole*
+                  - !Sub arn:${AWS::Partition}:iam::${TerraformEngineAccount}:role/TerraformEngine/ServiceCatalogExternalParameterParserRole*
       Policies:
         - PolicyName: ProvisioningArtifactAccessPolicy
           PolicyDocument:


### PR DESCRIPTION
*Issue #, if available: 

Resolves #67

*Description of changes:*

The example launch role is missing trust role policy for the new parser name `ServiceCatalogExternalParameterParserRole`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
