### PR TITLE
Specify LogGroupName for state machine logs 

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -1241,6 +1241,7 @@ Resources:
   ManageProvisionedProductStateMachineLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
+      LogGroupName: "/aws/vendedlogs/states/ManageProvisionedProductStateMachine"
       RetentionInDays: 3653
     UpdateReplacePolicy: Retain
     DeletionPolicy: Retain
@@ -1315,6 +1316,7 @@ Resources:
   TerminateProvisionedProductStateMachineLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
+      LogGroupName: "/aws/vendedlogs/states/TerminateProvisionedProductStateMachine"
       RetentionInDays: 3653
     UpdateReplacePolicy: Retain
     DeletionPolicy: Retain


### PR DESCRIPTION
...to fix issue with log resource policy size limits

Some customer are running into an "Invalid Logging Configuration" error from Step Functions due to the size restriction on the target log group's resource policy. This change fixes that issue by supplying a log group name with the proper prefix as stated in their documentation.

https://docs.aws.amazon.com/step-functions/latest/dg/bp-cwl.html

*Issue #, if available:* https://github.com/aws-samples/service-catalog-engine-for-terraform-os/issues/83

*Description of changes:* Sets the LogGroupName field for the log groups attached to the state machines per the instructions in the Step Functions documentation


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

*Testing:* `./bin/bash/deploy-tre.sh -r us-east-1`
